### PR TITLE
Handle integer overflows when multiplying gold/exp gains

### DIFF
--- a/Core/Patchers/PlayerPatchers.cs
+++ b/Core/Patchers/PlayerPatchers.cs
@@ -54,7 +54,12 @@ namespace PortiaHelper.Core.Patchers
 	{
 		[HarmonyPrefix]
 		static void Prefix(ref int exp) {
-			exp = exp > 0 ? Convert.ToInt32(exp * Central.Instance.PlayerOptions.ExpRatio) : exp;
+            try {
+                exp = exp > 0 ? Convert.ToInt32(exp * Central.Instance.PlayerOptions.ExpRatio) : exp;
+            } catch (OverflowException) {
+                Main.Logger.Log("Capping exp increase to max Int32");
+                exp = Int32.MaxValue;
+            }
 		}
 	}
 
@@ -63,7 +68,12 @@ namespace PortiaHelper.Core.Patchers
 	{
 		[HarmonyPrefix]
 		static void Prefix(ref int baseValue) {
-			baseValue = baseValue > 0 ? Convert.ToInt32(baseValue * Central.Instance.PlayerOptions.GoldRatio) : baseValue;
+            try {
+                baseValue = baseValue > 0 ? Convert.ToInt32(baseValue * Central.Instance.PlayerOptions.GoldRatio) : baseValue;
+            } catch (OverflowException) {
+                Main.Logger.Log("Capping money increase to max Int32");
+                baseValue = Int32.MaxValue;
+            }
 		}
 	}
 


### PR DESCRIPTION
Ran into a crash resulting from Portia Helper's gold multiplier being set too high, causing it to attempt to add more gold than what an `Int32` can hold.  This PR should fix that, at least as far as this mod is concerned; shenanigans will likely ensue in the game code, since it doesn't look like Pathea is guarding against this, either (what are the chances someone will ever be a billionaire in the game, right?), but that's probably something a dedicated bugfix mod should handle.